### PR TITLE
Draft: Add publications page

### DIFF
--- a/content/en/publications/2016.md
+++ b/content/en/publications/2016.md
@@ -1,0 +1,38 @@
+---
+title: '2016'
+date: 2021-24-01
+menu:
+  footer_secondary:
+---
+
+1. Lopez-Guadamillas E, Fernandez-Marcos PJ, Pantoja C, Muñoz-Martin M, Martínez D, **Gómez-López G**, Campos-Olivas R, Valverde AM, Serrano M. p21(Cip1) plays acritical role in the physiological adaptation to fasting through activation of PPARα. **_Sci Rep_**. 2016 Oct 10;6:34542. PubMed PMID: 27721423
+
+1. Koumarianou P, **Goméz-López G**, Santisteban P. Pax8 controls thyroid follicular polarity through Cadherin-16. J Cell Sci. 2016 Oct 25. PubMed PMID: 27780871
+
+1. García-Fernández M, Karras P, Checinska A, Cañón E, Calvo GT, **Gómez-López G**, Cifdaloz M, Colmenar A, Espinosa-Hevia L, Olmeda D, Soengas MS. Metastatic risk and resistance to BRAF inhibitors in melanoma defined by selective allelic loss of ATG5. Autophagy. 2016 Oct 2;12(10):1776-1790. PubMed PMID: 27464255
+
+1. García-Carpizo V, Sarmentero J, Han B, **Graña O**, Ruiz-Llorente S, Pisano DG, Serrano M, Brooks HB, Campbell RM, Barrero MJ. NSD2 contributes to oncogenic RAS-driven transcription in lung cancer cells through long-range epigenetic activation. Sci Rep. 2016 Sep 8;6:32952. PubMed PMID: 27604143
+
+1. Mancikova V, Montero-Conde C, Perales-Paton J, Fernandez AF, Santacana M, Jodkowska K, Inglada-Pérez L, Castelblanco E, Borrego S, Encinas M, Matias-Guiu X, Fraga MF, Robledo M. Multilayer OMIC data in medullary thyroid carcinoma identifies the STAT3 pathway as a potential therapeutic target in RETM918T tumors. Clin Cancer Res. 2016 Sep 12. PubMed PMID: 27620278
+
+1. Martínez P, Gómez-López G, Pisano DG, Flores JM, Blasco MA. A genetic interaction between RAP1 and telomerase reveals an unanticipated role for RAP1 in telomere maintenance. Aging Cell. 2016 Sep PubMed PMID: 27586969
+
+1. Montero JJ, López de Silanes I, Graña O, Blasco MA. Telomeric RNAs are essential to maintain telomeres. Nat Commun. 2016 Aug 17;7:12534. PubMed PMID: 27531349
+
+1. Apellániz-Ruiz M, Tejero H, Inglada-Pérez L, Sánchez-Barroso L, Gutiérrez-Gutiérrez G, Calvo I, Castelo B, Redondo A, García-Donás J, Romero-Laorden N, Sereno M, Merino M, Currás-Freixes M, Montero-Conde C, Mancikova V, Åvall-Lundqvist E, Green H, Al-Shahrour F, Cascon A, Robledo M, Rodriguez-Antona C. Targeted sequencing reveals low-frequency variants in EPHA genes as markers of paclitaxel-induced peripheral neuropathy. Clin Cancer Res. 2016 Aug 31. PubMed PMID: 27582484
+
+1. García-Donas J, Beuselinck B, Inglada-Pérez L, Graña O, Schöffski P, Wozniak A, Bechter O, Apellániz-Ruiz M, Leandro-García LJ, Esteban E, Castellano DE, González Del Alba A, Climent MA, Hernando S, Arranz JA, Morente M, Pisano DG, Robledo M, Rodriguez-Antona C. Deep sequencing reveals microRNAs predictive of antiangiogenic drug response. JCI Insight. 2016 Jul 7;1(10):e86051. PubMed PMID: 27699216
+
+1. Navarro P, Bueno MJ, Zagorac I, Mondejar T, Sanchez J, Mourón S, Muñoz J, Gómez-López G, Jimenez-Renard V, Mulero F, Chandel NS, Quintela-Fandino M. Targeting Tumor Mitochondrial Metabolism Overcomes Resistance to Antiangiogenics. Cell Rep. 2016 Jun 21;15(12):2705-18. PubMed PMID: 27292634
+
+1. Manso L, Mourón S, Tress M, Gómez-López G, Morente M, Ciruelos E, Rubio-Camarillo M, Rodriguez-Peralto JL, Pujana MA, Pisano DG, Quintela-Fandino M. Analysis of Paired Primary-Metastatic Hormone-Receptor Positive Breast Tumors (HRPBC) Uncovers Potential Novel Drivers of Hormonal Resistance. PLoS One. 2016 May 19;11(5):e0155840. PubMed PMID: 27195705
+
+1. Puram RV, Kowalczyk MS, de Boer CG, Schneider RK, Miller PG, McConkey M, Tothova Z, Tejero H, Heckl D, Järås M, Chen MC, Li H, Tamayo A, Cowley GS, Rozenblatt-Rosen O, Al-Shahrour F, Regev A, Ebert BL. Core Circadian Clock Genes Regulate Leukemia Stem Cells in AML. Cell. 2016 Apr 7;165(2):303-16. PubMed PMID: 27058663
+
+1. Ferrer-Mayorga G, Gómez-López G, Barbáchano A, Fernández-Barral A, Peña C, Pisano DG, Cantero R, Rojo F, Muñoz A, Larriba MJ. Vitamin D receptor expression and associated gene signature in tumour stromal fibroblasts predict clinical outcome in colorectal cancer. Gut. 2016 Apr 6. PubMed PMID: 27053631
+
+1. Elf S, Abdelfattah NS, Chen E, Perales-Patón J, Rosen EA, Ko A, Peisker F, Florescu N, Giannini S, Wolach O, Morgan EA, Tothova Z, Losman JA, Schneider RK, Al-Shahrour F, Mullally A. Mutant Calreticulin Requires Both Its Mutant C-terminus and the Thrombopoietin Receptor for Oncogenic Transformation. Cancer Discov. 2016 Apr;6(4):368-81. PubMed PMID: 26951227
+
+1. Uluçkan Ö, Jimenez M, Karbach S, Jeschke A, Graña O, Keller J, Busse B, Croxford AL, Finzel S, Koenders M, van den Berg W, Schinke T, Amling M, Waisman A, Schett G, Wagner EF. Chronic skin inflammation leads to bone loss by IL-17-mediated inhibition of Wnt signaling in osteoblasts. Sci Transl Med. 2016 Mar 16;8(330):330ra37. PubMed PMID: 27089206
+
+1. Ambrogio C, Gómez-López G, Falcone M, Vidal A, Nadal E, Crosetto N, Blasco RB, Fernández-Marcos PJ, Sánchez-Céspedes M, Ren X, Wang Z, Ding K, Hidalgo M, Serrano M, Villanueva A, Santamaría D, Barbacid M. Combined inhibition of DDR1 and Notch signaling is a therapeutic strategy for KRAS-driven lung adenocarcinoma. Nat Med. 2016 Mar;22(3):270-7. PubMed PMID: 26855149

--- a/content/en/publications/2017.md
+++ b/content/en/publications/2017.md
@@ -1,0 +1,51 @@
+---
+title: '2017'
+date: 2021-24-01
+menu:
+  footer_secondary:
+---
+1. Apellániz-Ruiz M, Tejero H, Inglada-Pérez L, Sánchez-Barroso L, Gutiérrez-Gutiérrez G, Calvo I, Castelo B, Redondo A, García-Donás J, Romero-Laorden N, Sereno M, Merino M, Currás-Freixes M, Montero-Conde C, Mancikova V, Åvall-Lundqvist E, Green H, Al-Shahrour F, Cascón A, Robledo M, Rodríguez-Antona C. Targeted Sequencing Reveals Low-Frequency Variants in EPHA Genes as Markers of Paclitaxel-Induced Peripheral Neuropathy. Clin Cancer Res. 2017 Mar 1;23(5):1227-1235. doi: 10.1158/1078-0432.CCR-16-0694. PubMed PMID: 27582484.
+
+1. Vu LP, Prieto C, Amin EM, Chhangawala S, Krivtsov A, Calvo-Vidal MN, Chou T, Chow A, Minuesa G, Park SM, Barlowe TS, Taggart J, Tivnan P, Deering RP, Chu LP, Kwon JA, Meydan C, Perales-Paton J, Arshi A, Gönen M, Famulare C, Patel M, Paietta E, Tallman MS, Lu Y, Glass J, Garret-Bakelman FE, Melnick A, Levine R, Al-Shahrour F, Järås M, Hacohen N, Hwang A, Garippa R, Lengner CJ, Armstrong SA,  Cerchietti L, Cowley GS, Root D, Doench J, Leslie C, Ebert BL, Kharas MG. Functional screen of MSI2 interactors identifies an essential role for SYNCRIP in myeloid leukemia stem cells. Nat Genet. 2017 Jun;49(6):866-875. doi: 10.1038/ng.3854. PubMed PMID: 28436985
+
+1. Romero-Laorden N, Piñeiro-Yañez E, Gutierrez-Pecharroman A, Pacheco MI, Calvo E, Al-Shahrour F, Castro E, Olmos D. Somatic BRCA2 bi-allelic loss in the primary prostate cancer was associated to objective response to PARPi in a sporadic CRPC. Ann Oncol. 2017 May 1;28(5):1158-1159. doi: 10.1093/annonc/mdx067. PubMed PMID: 28453706.
+
+1. Currás-Freixes M, Piñeiro-Yañez E, Montero-Conde C, Apellániz-Ruiz M, Calsina B, Mancikova V, Remacha L, Richter S, Ercolino T, Rogowski-Lehmann N, Deutschbein T, Calatayud M, Guadalix S, Álvarez-Escolá C, Lamas C, Aller J, Sastre-Marcos J,  Lázaro C, Galofré JC, Patiño-García A, Meoro-Avilés A, Balmaña-Gelpi J, De Miguel-Novoa P, Balbín M, Matías-Guiu X, Letón R, Inglada-Pérez L, Torres-Pérez R, Roldán-Romero JM, Rodríguez-Antona C, Fliedner SMJ, Opocher G, Pacak K, Korpershoek E, de Krijger RR, Vroonen L, Mannelli M, Fassnacht M, Beuschlein F, Eisenhofer G, Cascón A, Al-Shahrour F, Robledo M. PheoSeq: A Targeted Next-Generation Sequencing Assay for Pheochromocytoma and Paraganglioma Diagnostics. J Mol Diagn. 2017 Jul;19(4):575-588. doi: 10.1016/j.jmoldx.2017.04.009. PubMed PMID: 28552549.
+
+1. Rajeshkumar NV, Yabuuchi S, Pai SG, De Oliveira E, Kamphorst JJ, Rabinowitz JD, Tejero H, Al-Shahrour F, Hidalgo M, Maitra A, Dang CV. Treatment of Pancreatic Cancer Patient-Derived Xenograft Panel with Metabolic Inhibitors Reveals Efficacy of Phenformin. Clin Cancer Res. 2017 Sep 15;23(18):5639-5647. doi: 10.1158/1078-0432.CCR-17-1115. PubMed PMID: 28611197.
+
+1. Sánchez-Valle J, Tejero H, Ibáñez K, Portero JL, Krallinger M, Al-Shahrour F, Tabarés-Seisdedos R, Baudot A, Valencia A. A molecular hypothesis to explain direct and inverse co-morbidities between Alzheimer’s Disease, Glioblastoma and Lung cancer. Sci Rep. 2017 Jun 30;7(1):4474. doi: 10.1038/s41598-017-04400-6. PubMed PMID: 28667284.
+
+1. Perales-Patón J, Piñeiro-Yañez E, Tejero H, López-Casas PP, Hidalgo M, Gómez-López G, Al-Shahrour F. Pancreas Cancer Precision Treatment Using Avatar Mice from a Bioinformatics Perspective. Public Health Genomics. 2017;20(2):81-91. doi: 10.1159/000479812. PubMed PMID: 28858862.
+
+1. Gómez-López G, Dopazo J, Cigudosa JC, Valencia A, Al-Shahrour F. Precision medicine needs pioneering clinical bioinformaticians. Brief Bioinform. 2017 Oct 25. doi: 10.1093/bib/bbx144. PubMed PMID: 29077790.
+
+1. Cifdaloz M, Osterloh L, Graña O, Riveiro-Falkenbach E, Ximénez-Embún P, Muñoz J, Tejedo C, Calvo TG, Karras P, Olmeda D, Miñana B, Gómez-López G, Cañon E, Eyras E, Guo H, Kappes F, Ortiz-Romero PL, Rodríguez-Peralto JL, Megías D, Valcárcel J, Soengas MS. Systems analysis identifies melanoma-enriched pro-oncogenic networks controlled by the RNA binding protein CELF1. Nat Commun. 2017 Dec 21;8(1):2249. doi: 10.1038/s41467-017-02353-y. PubMed PMID: 29269732.
+
+1. Nieto P, Ambrogio C, Esteban-Burgos L, Gómez-López G, Blasco MT, Yao Z, Marais R, Rosen N, Chiarle R, Pisano DG, Barbacid M, Santamaría D. A Braf kinase-inactive mutant induces lung adenocarcinoma. Nature. 2017 Aug 10;548(7666):239-243. doi: 10.1038/nature23297. PubMed PMID: 28783725.
+
+1. Rio-Machin A, Gómez-López G, Muñoz J, Garcia-Martinez F, Maiques-Diaz A, Alvarez S, Salgado RN, Shrestha M, Torres-Ruiz R, Haferlach C, Larráyoz MJ, Calasanz MJ, Fitzgibbon J, Cigudosa JC. The molecular pathogenesis of the NUP98-HOXA9 fusion protein in acute myeloid leukemia. Leukemia. 2017 Sep;31(9):2000-2005. doi: 10.1038/leu.2017.194. PubMed PMID: 28630438.
+
+1. Gimenez-Xavier P, Pros E, Bonastre E, Moran S, Aza A, Graña O, Gomez-Lopez G, Derdak S, Dabad M, Esteve-Codina A, Hernandez Mora JR, Salinas-Chaparro D, Esteller M, Pisano D, Sanchez-Cespedes M. Genomic and Molecular Screenings Identify Different Mechanisms for Acquired Resistance to MET Inhibitors in Lung Cancer Cells. Mol Cancer Ther. 2017 Jul;16(7):1366-1376. doi: 10.1158/1535-7163.MCT-17-0104. PubMed PMID: 28396363.
+
+1. Pereira C, Gimenez-Xavier P, Pros E, Pajares MJ, Moro M, Gomez A, Navarro A, Condom E, Moran S, Gomez-Lopez G, Graña O, Rubio-Camarillo M, Martinez-Martí A, Yokota J, Carretero J, Galbis JM, Nadal E, Pisano D, Sozzi G, Felip E, Montuenga LM, Roz L, Villanueva A, Sanchez-Cespedes M. Genomic Profiling of Patient-Derived Xenografts for Lung Cancer Identifies B2M Inactivation Impairing Immunorecognition. Clin Cancer Res. 2017 Jun 15;23(12):3203-3213. doi: 10.1158/1078-0432.CCR-16-1946. PubMed PMID: 28302866.
+
+1. Andrés-León E, Gómez-López G, Pisano DG. Prediction of miRNA-mRNA Interactions Using miRGate. Methods Mol Biol. 2017;1580:225-237. doi: 10.1007/978-1-4939-6866-4_15. PubMed PMID: 28439836.
+
+1. Rubio-Camarillo M, López-Fernández H, Gómez-López G, Carro Á, Fernández JM, Torre CF, Fdez-Riverola F, Glez-Peña D. RUbioSeq+: A multiplatform application that executes parallelized pipelines to analyse next-generation sequencing data. Comput Methods Programs Biomed. 2017 Jan;138:73-81. doi: 10.1016/j.cmpb.2016.10.008. PubMed PMID: 27886717.
+
+1. Graña O, López-Fernández H, Fdez-Riverola F, González Pisano D, Glez-Peña D. Bicycle: a bioinformatics pipeline to analyze bisulfite sequencing data. Bioinformatics. 2017 Dec 1. doi: 10.1093/bioinformatics/btx778. PubMed PMID: 29211825.
+
+1. Simón-Carrasco L, Graña O, Salmón M, Jacob HKC, Gutierrez A, Jiménez G, Drosten M, Barbacid M. Inactivation of Capicua in adult mice causes T-cell lymphoblastic lymphoma. Genes Dev. 2017 Jul 15;31(14):1456-1468. doi: 10.1101/gad.300244.117. PubMed PMID: 28827401
+
+1. Olmeda D, Cerezo-Wallis D, Riveiro-Falkenbach E, Pennacchi PC, Contreras-Alcalde M, Ibarz N, Cifdaloz M, Catena X, Calvo TG, Cañón E, Alonso-Curbelo D, Suarez J, Osterloh L, Graña O, Mulero F, Megías D, Cañamero M, Martínez-Torrecuadrada JL, Mondal C, Di Martino J, Lora D, Martinez-Corral I, Bravo-Cordero JJ, Muñoz J, Puig S, Ortiz-Romero P, Rodriguez-Peralto JL, Ortega S, Soengas MS. Whole-body imaging of lymphovascular niches identifies pre-metastatic roles of midkine. Nature. 2017 Jun 28;546(7660):676-680. doi: 10.1038/nature22977. PubMed PMID: 28658220.
+
+1. Esteban-Martínez L, Sierra-Filardi E, McGreal RS, Salazar-Roa M, Mariño G, Seco E, Durand S, Enot D, Graña O, Malumbres M, Cvekl A, Cuervo AM, Kroemer G, Boya P. Programmed mitophagy is essential for the glycolytic switch during cell differentiation. EMBO J. 2017 Jun 14;36(12):1688-1706. doi: 10.15252/embj.201695916. PubMed PMID: 28465321
+
+1. Tummala KS, Brandt M, Teijeiro A, Graña O, Schwabe RF, Perna C, Djouder N. Hepatocellular Carcinomas Originate Predominantly from Hepatocytes and Benign Lesions from Hepatic Progenitor Cells. Cell Rep. 2017 Apr 18;19(3):584-600. doi: 1016/j.celrep.2017.03.059. PubMed PMID: 28423321
+
+1. Bakiri L, Hamacher R, Graña O, Guío-Carrión A, Campos-Olivas R, Martinez L, Dienes HP, Thomsen MK, Hasenfuss SC, Wagner EF. Liver carcinogenesis by FOS-dependent inflammation and cholesterol dysregulation. J Exp Med. 2017 May 1;214(5):1387-1409. doi: 10.1084/jem.20160935. PubMed PMID: 28356389
+
+1. Mancikova V, Montero-Conde C, Perales-Paton J, Fernandez A, Santacana M, Jodkowska K, Inglada-Pérez L, Castelblanco E, Borrego S, Encinas M, Matias-Guiu X, Fraga M, Robledo M. Multilayer OMIC Data in Medullary Thyroid Carcinoma Identifies the STAT3 Pathway as a Potential Therapeutic Target in RET(M918T) Tumors. Clin Cancer Res. 2017 Mar 1;23(5):1334-1345. doi: 10.1158/1078-0432.CCR-16-0947. PubMed PMID: 27620278.
+
+1. Wasilewski D, Priego N, Fustero-Torre C, Valiente M. Reactive Astrocytes in Brain Metastasis. Front. Oncol. 11 December 2017. doi: 10.3389/fonc.2017.00298. PMID: 29312881

--- a/content/en/publications/2018.md
+++ b/content/en/publications/2018.md
@@ -1,0 +1,34 @@
+---
+title: '2018'
+date: 2021-24-01
+menu:
+  footer_secondary:
+---
+
+1. Paumard-Hernández B, Calvete O, Inglada Pérez L, Tejero H, Al-Shahrour F, Pita G, Barroso A, Carlos Triviño J, Urioste M, Valverde C, González Billalabeitia E, Quiroga V, Francisco Rodríguez Moreno J, Fernández Aramburo A, López C, Maroto P, Sastre J, José Juan Fita M, Duran I, Lorenzo-Lorenzo I, Iranzo P, García Del Muro X, Ros S, Zambrana F, María Autran A, Benítez J. Whole exome sequencing identifies PLEC, EXO5 and DNAH7 as novel susceptibility genes in testicular cancer. Int J Cancer 2018 Oct 15;143(8):1954-1962. PubMed PMID: 29761480 [Article]
+
+1. Abascal F, Juan D, Jungreis I, Martinez L, Rigau M, Rodriguez JM, Vazquez J, Tress ML. Loose ends: almost one in five human genes still have unresolved coding status. Nucleic Acids Res. 2018 Aug 21;46(14):7070-7084. PubMed PMID: 29982784 [Article]
+
+1. Zagorac I, Fernandez S, Penning R, Post H, Bueno MJ, Mouron S, Manso L, Morente MM, Alonso S, Serra V, Muñoz J, Gómez-López G, Jimenez-Renard V, Al-Shahrour F, Piñeiro-Yañez E, Pujana MA, Mateo F, Villanueva A, Montoya-Suarez JL, Apala JV, Moreno-Torres A, Colomer R, Dopazo A, Heck A.J.R, Maarten Altelaar AF, Quintela-Fandino M. In vivo phosphoproteomics reveals kinase activity profiles that predict treatment outcome in triple-negative breast cancer. Nat Commun.. 2018; 9(1):3501. PubMed PMID: 30158526. [Article]
+
+1. Valiño-Rivas L, Cuarental L, Grana O, Bucala R, Leng L, Sanz A, Gomez G, Ortiz A, Sanchez-Niño MD. TWEAK increases CD74 expression and sensitizes to DDT proinflammatory actions in tubular cells. PLoS One. 2018 Jun 20. PubMed PMID: 29924850 . [Article]
+
+1. Priego N, Zhu L, Monteiro C, Mulders M, Wasilewski D, Bindeman W, Doglio L, Martínez L, Martínez-Saez E, Cajal SRY, Megías D, Hernández-Encinas E, Blanco-Aparicio C, Martínez L, Zarzuela E, Muñoz J, Fustero-Torre C, Piñeiro-Yáñez E, Hernández-Laín A, Bertero L, Poli V, Sanchez-Martinez M, Menendez JA, Soffietti R, Bosch-Barrera J, Valiente M. STAT3 labels a subpopulation of reactive astrocytes required for brain metastasis. Nat Med. 2018 Jun 11. PubMed PMID: 29892069. [Article]
+
+1. Garcia-Carpizo V, Ruiz-Llorente S, Sarmentero J, Graña-Castro O, Pisano DG, Barrero MJ. CREBBP/EP300 bromodomains are critical to sustain the GATA1/MYC regulatory axis in proliferation. Epigenetics Chromatin. 2018 Jun 8;11(1):30. PubMed PMID: 29884215. [Article]
+
+1. Elena Piñeiro-Yáñez, Miguel Reboiro-Jato, Gonzalo Gómez-López, Javier Perales-Patón, Kevin Troulé, José Manuel Rodríguez, Héctor Tejero, Takeshi Shimamura, Pedro Pablo López-Casas, Julián Carretero, Alfonso Valencia, Manuel Hidalgo, Daniel Glez-Peña and Fátima Al-Shahrour. PanDrugs: a novel method to prioritize anticancer drug treatments according to individual genomic data. Genome Med. 2018; 10:41. PubMed PMID: 29848362. [Article]
+
+1. Aleksandar Kojic, Ana Cuadrado, Magali De Koninck, Daniel Giménez-Llorente, Miriam Rodríguez-Corsino, Gonzalo Gómez-López, François Le Dily, Marc A. Marti-Renom, Ana Losada. Distinct roles of    cohesin-SA1 and cohesin-SA2 in 3D chromosome organization. Nat Struct Mol Biol. 2018. DOI: 10.1038/s41594-018-0070-4. PubMed PMID: 29867216. 
+
+1. López-Nieva P, Fernández-Navarro P, Vaquero-Lorenzo C, Villa-Morales M, Graña-Castro O, Cobos-Fernández MÁ, López-Lorenzo JL, Llamas P, González-Sanchez L, Sastre I, Pollan M, Malumbres M, Santos J, Fernández-Piqueras J. RNA-Seq reveals the existence of a CDKN1C-E2F1-TP53 axis that is altered in human T-cell lymphoblastic lymphomas. BMC Cancer. 2018; 18(1):430. PubMed PMID: 29661169. PMCID: PMC5902834.
+
+1. Oldrini B, Curiel-García Á, Marques C, Matia V, Uluçkan Ö, Graña-Castro O, Torres-Ruiz R, Rodriguez-Perales S, Huse JT, Squatrito M. Somatic genome editing with the RCAS-TVA-CRISPR-Cas9 system for precision tumor modeling. Nat Commun. 2018; 9(1):1466. PubMed PMID: 29654229. PMCID: PMC5899147.
+
+1. Djurec M, Graña O, Lee A, Troulé K, Espinet E, Cabras L, Navas C, Blasco MT, Martín-Díaz L, Burdiel M, Li J, Liu Z, Vallespinós M, Sanchez-Bueno F, Sprick MR, Trumpp A, Sainz B Jr., Al-Shahrour F, Rabadan R, Guerra C, Barbacid M. Saa3 is a key mediator of the protumorigenic properties of cancer-associated fibroblasts in pancreatic tumors. Proc Natl Acad Sci U S A. 2018 Feb 6;115(6):E1147-E1156. doi: 10.1073/pnas.1717802115. PubMed PMID: 29351990.
+
+1. Juan Manuel Povedano, Paula Martinez, Rosa Serrano, Águeda Tejera, Gonzalo Gómez-López, Maria Bobadilla, Juana Maria Flores, Fátima Bosch, Maria A Blasco. Therapeutic effects of telomerase in mice with pulmonary fibrosis induced by damage to the lungs and short telomeres. Elife. 2018 Jan 30;7. pii: e31299. doi: 10.7554/eLife.31299. PubMed PMID: 29378675.
+
+1. Lynch CJ, Bernad R, Calvo I, Nóbrega-Pereira S, Ruiz S, Ibarz N, Martinez-Val A, Graña-Castro O, Gómez-López G, Andrés-León E, Espinosa Angarica V, Del Sol A, Ortega S, Fernandez-Capetillo O, Rojo E, Munoz J, Serrano M. The RNA Polymerase II Factor RPAP1 Is Critical for Mediator-Driven Transcription and Cell Identity. Cell Rep. 2018 Jan 9;22(2):396-410. doi: 10.1016/j.celrep.2017.12.062. PubMed PMID: 29320736.
+
+1. O. Graña; M. Rubio-Camarillo; F. Fdez-Riverola; D.G. Pisano; D. Glez-Peña. Nextpresso: next generation sequencing expression analysis pipeline. Current Bioinformatics 2018. Volume 13 (6):583 – 591. DOI: 10.2174/1574893612666170810153850. [Article]

--- a/content/en/publications/2019.md
+++ b/content/en/publications/2019.md
@@ -1,0 +1,49 @@
+---
+title: '2019'
+date: 2021-24-01
+menu:
+  footer_secondary:
+---
+
+
+1. MEK inhibition enhances the response to tyrosine kinase inhibitors in acute myeloid leukemia. Morales ML, Arenas A, Ortiz-Ruiz A, Leivas A, Rapado I, Rodríguez-García A, Castro N, Zagorac I, Quintela-Fandino M, Gómez-López G, Gallardo M, Ayala R, Linares M, Martínez-López J. Sci Rep. 2019 Dec 9;9(1):18630. doi: 10.1038/s41598-019-54901-9. PubMed PMID: 31819100 [Article]
+
+1. Global Transcriptomic Profiling of the Bone Marrow Stromal Microenvironment during Postnatal Development, Aging, and Inflammation. Helbling PM, Piñeiro-Yáñez E, Gerosa R, Boettcher S, Al-Shahrour F, Manz MG, Nombela-Arrieta C. Cell Rep. 2019 Dec 3;29(10):3313-3330.e4. doi: 10.1016/j.celrep.2019.11.004. PubMed PMID: 31801092 [Article]
+
+1. The correlation between immune subtypes and consensus molecular subtypes in colorectal cancer identifies novel tumour microenvironment profiles, with prognostic and therapeutic implications. B. Soldevilla, C. Carretero-Puche, G. Gómez-López, F. Al-Shahrour, MC. Riesco, B. Gil-Calderon, L. Alvarez-Vallina, P. Espinosa-Olarte, G. Gómez-Esteves, B. Rubio-Cuesta, J. Sarmentero, A. La Salvia, R. Garcia-Carbonero. Eur J Cancer. 2019 Oct 31;123:118-129. doi: 10.1016/j.ejca.2019.09.008. PubMed PMID: 31678770 [Article]
+
+1. The use of PanDrugs to prioritize anticancer drug treatments in a case of T-ALL based on individual genomic data. Fernández-Navarro P, López-Nieva P, Piñeiro-Yañez E, Carreño-Tarragona G, Martinez-López J, Sánchez Pérez R, Aroca Á, Al-Shahrour F, Cobos-Fernández MÁ, Fernández-Piqueras J. BMC Cancer. 2019 Oct 26;19(1):1005. doi: 10.1186/s12885-019-6209-9. PubMed PMID: 31655559 [Article]
+
+1. Role of bulge epidermal stem cells and TSLP signaling in psoriasis. Nuria Gago‐Lopez, Liliana F Mellor, Diego Megías, Guillermo Martín‐Serrano, Ander Izeta, Francisco Jimenez, Erwin F Wagner. EMBO Mol Med. 2019, 26 Sep, e10697; https://doi.org/10.15252/emmm.201910697. PubMed PMID: 31556482 [Article]
+
+1. In silico drug prescription for targeting cancer patient heterogeneity and prediction of clinical outcome. Elena Piñeiro-Yáñez, María José Jiménez-Santos, Gonzalo Gómez-López, Fátima Al-Shahrour. Cancers. 2019, 11(9), 1361; https://doi.org/10.3390/cancers11091361. PubMed PMID: 31540260 [Article]
+
+1. Oncogenic Rag GTPase signalling enhances B cell activation and drives follicular lymphoma sensitive to pharmacological inhibition of mTOR. Ortega-Molina A, Deleyto-Seldas N, Carreras J, Sanz A, Lebrero-Fernández C, Menéndez C, Vandenberg A, Fernández-Ruiz B, Marín-Arraiza L, Calle Arregui C, Plata-Gómez A, Caleiras E, de Martino A, Martínez-Martín N, Troulé K, Piñeiro-Yañez E, Nakamura N, Araf S, Victoria G, Okosun J, Fitzgibbon, Efeyan A. Nat. Metab. 2019, Aug, doi: 10.1038/s42255-019-0098-8. PubMed PMID: 31579886 [Article]
+
+1. Lymphatic vessels interact dynamically with the hair follicle stem cell niche during skin regeneration in vivo. Peña-Jimenez D, Fontenete S, Megias D, Fustero-Torre C, Graña-Castro O, Castellana D, Loewe R, Perez-Moreno M. EMBO J. 2019 Sep 2:e101688. doi: 10.15252/embj.2019101688. PubMed PMID: 31475747 [Article]
+
+1. TERRA regulate the transcriptional landscape of pluripotent cells through TRF1-dependent recruitment of PRC2. Marión RM, Montero JJ, López de Silanes I, Graña-Castro O, Martínez P, Schoeftner S, Palacios-Fábrega JA, Blasco MA. Elife. 2019 Aug 20; 8 (pii: e44656). doi: 10.7554/eLife.44656. PubMed PMID: 31426913 [Article]
+
+1. Hsa-miR-139-5p is a prognostic thyroid cancer marker involved in HNRNPF-mediated alternative splicing. Montero-Conde C, Graña-Castro O, Martín-Serrano G, Martínez-Montes ÁM, Zarzuela E, Muñoz J, Torres-Perez R, Pita G, Cordero-Barreal A, Leandro-García LJ, Letón R, de Silanes IL, Guadalix S, Pérez-Barrios A, Hawkins F, Guerrero-Álvarez A, Álvarez-Escolá C, Regojo-Zapata R, Calsina B, Remacha L, Roldán-Romero JM, Santos M, Lanillos J, Jordá M, Riesco-Eizaguirre G, Zafon C, González-Neira A, Blasco MA, Al-Shahrour F, Rodríguez-Antona C, Cascón A, Robledo M. Int J Cancer. 2019 Aug 12; doi: 10.1002/ijc.32622. PubMed PMID: 31403184 [Article]
+
+1. Integrative multi-omics analysis identifies a prognostic miRNA signature and a targetable miR-21-3p/TSC2/mTOR axis in metastatic pheochromocytoma/paraganglioma. Calsina B, Castro-Vega LJ, Torres-Pérez R, Inglada-Pérez L, Currás-Freixes M, Roldán-Romero JM, Mancikova V, Letón R, Remacha L, Santos M, Burnichon N, Lussey-Lepoutre C, Rapizzi E, Graña O, Álvarez-Escolá C, A de Cubas A, Lanillos J, Cordero-Barreal A, Martínez-Montes AM, Bellucci A, Amar L, Luiz Fernandes-Rosa F, Calatayud M, Aller J, Lamas C, Sastre-Marcos J, Canu L, Korpershoek E, Timmers HJ, Lenders JWM, Beuschlein F, Fassnacht-Capeller M, Eisenhofer G, Mannelli M, Al-Shahrour F, Favier J, Rodríguez-Antona C, Cascón A, Montero-Conde C, Gimenez-Roqueplo AP, Robledo M. Theranostics. 2019; 9(17):4946-4958. doi:10.7150/thno.35458. PubMed PMID: 31410193 [Article]
+
+1. Specific contributions of Cohesin-SA1 and Cohesin-SA2 to TADs and Polycomb domains in embryonic stem cells. Cuadrado A, Giménez-Llorente D, Kojic A, Rodríguez-Corsino M, Cuartero Y, Martín-Serrano G, Gómez-López G, Marti-Renom MA, Losada A. Cell Reports. 2019 Jun 18;27(12):3500-3510.e4. doi: 10.1016/j.celrep.2019.05.078. PubMed PMID: 31216471 [Article]
+
+1. vulcanSpot: a tool to prioritize therapeutic vulnerabilities in cancer. Perales-Patón J, Di Domenico T, Fustero-Torre C, Piñeiro-Yáñez E, Carretero-Puche C, Tejero H, Valencia A, Gómez-López G, Al-Shahrour F. Bioinformatics. 2019 Jun 7. pii: btz465. doi: 10.1093/bioinformatics/btz465. PubMed PMID: 31173067 [Article]
+
+1. Blasco MT, Navas C, Martín-Serrano G, Graña-Castro O, Lechuga CG, Martín-Díaz L, Djurec M, Li J, Morales-Cacho L, Esteban-Burgos L, Perales-Patón J, Bousquet-Mur E, Castellano E, Jacob HKC, Cabras L, Musteanu M, Drosten M, Ortega S, Mulero F, Sainz B Jr, Dusetti N, Iovanna J, Sánchez-Bueno F, Hidalgo M, Khiabanian H, Rabadán R, Al-Shahrour F, Guerra C, Barbacid M. Complete Regression of Advanced Pancreatic Ductal Adenocarcinomas upon Combined Inhibition of EGFR and C-RAF. Cancer Cell. 2019 Apr 8. pii: S1535-6108(19)30111-4. PubMed PMID: 30975481 [Article]
+
+1. Urdinguio RG, Lopez V, Bayón GF, Diaz de la Guardia R, Sierra MI, García-Toraño E, Perez RF, García MG, Carella A, Pruneda PC, Prieto C, Dmitrijeva M, Santamarina P, Belmonte T, Mangas C, Diaconu E, Ferrero C, Tejedor JR, Fernandez-Morera JL, Bravo C, Bueno C, Sanjuan-Pla A, Rodriguez RM, Suarez-Alvarez B, López-Larrea C, Bernal T, Colado E, Balbín M, García-Suarez O, Chiara MD, Sáenz-de-Santa-María I, Rodríguez F, Pando-Sandoval A, Rodrigo L, Santos L, Salas A, Vallejo-Díaz J, C Carrera A, Rico D, Hernández-López I, Vayá A, Ricart JM, Seto E, Sima-Teruel N, Vaquero A, Valledor L, Cañal MJ, Pisano D, Graña-Castro O, Thomas T, Voss AK, Menéndez P, Villar-Garea A, Deutzmann R, Fernandez AF, Fraga MF. Chromatin regulation by Histone H4 acetylation at Lysine 16 during cell death and differentiation in the myeloid compartment. Nucleic Acids Res.. 2019 Mar 29. PubMed PMID: 30923829 [Article]
+
+1. López-Nieva P, Fernández-Navarro P, Graña-Castro O, Andrés-León E, Santos J, Villa-Morales M, Cobos-Fernández MÁ, González-Sánchez L, Malumbres M, Salazar-Roa M, Fernández-Piqueras J. Detection of novel fusion-transcripts by RNA-Seq in T-cell lymphoblastic lymphoma. Sci Rep. 2019 March 26;9:5179. PubMed PMID: 30914738 [Article]
+
+1. Vázquez-Domínguez I, González-Sánchez L, López-Nieva P, Fernández-Navarro P, Villa-Morales M, Cobos-Fernández MÁ, Sastre I, F Fraga M, F Fernández A, Malumbres M, Salazar-Roa M, Graña-Castro O, Santos J, Llamas P, López-Lorenzo JL, Fernández-Piqueras J. Clonal dynamics monitoring during clinical evolution in chronic lymphocytic leukaemia. Oncogene . 2019 Feb 11; doi:10.1038/s41388-019-0746-1. PubMed PMID: 30742097 [Article]
+
+1. González-Rincón, J., Gómez, S., Martinez, N., Troulé, K., Perales-Patón, J., Derdak, S., Beltrán, S., Fernández-Cuevas, B., Pérez-Sanz, N., Nova-Gurumeta, S., Gut, I., Al-Shahrour, F., Piris, M.A., García-Marco, J.A., Sánchez-Beato, M. Clonal dynamics monitoring during clinical evolution in chronic lymphocytic leukaemia. Sci Rep. 2019 Jan 30;9(1):975. PubMed PMID: 30700761 [Article]
+
+1. Panagiotis Karras, Erica Riveiro-Falkenbach, Estela Cañón, Cristina Tejedo, Tonantzin G. Calvo, Raúl Martínez-Herranz, Direna Alonso-Curbelo, Metehan Cifdaloz, Eva Perez-Guijarro, Gonzalo Gómez-López, Pilar Ximenez-Embun, Javier Muñoz, Diego Megias, David Olmeda, Jorge Moscat, Pablo L. Ortiz-Romero, Jose L. Rodríguez-Peralto, María S. Soengas. p62/SQSTM1 Fuels Melanoma Progression by Opposing mRNA Decay of a Selective Set of Pro-metastatic Factors. Cancer Cell. 2019. Volume 35, 2019-01, 1 – 18. PubMed PMID: 30581152 [Article]
+
+1. Frankish A, Diekhans M, Ferreira AM, Johnson R, Jungreis I, Loveland J, Mudge JM, Sisu C, Wright J, Armstrong J, Barnes I, Berry A, Bignell A, Carbonell Sala S, Chrast J, Cunningham F, Di Domenico T, Donaldson S, Fiddes IT, García Girón C, Gonzalez JM, Grego T, Hardy M, Hourlier T, Hunt T, Izuogu OG, Lagarde J, Martin FJ, Martínez L, Mohanan S, Muir P, Navarro FCP, Parker A, Pei B, Pozo F, Ruffier M, Schmitt BM, Stapleton E, Suner MM, Sycheva I, Uszczynska-Ratajczak B, Xu J, Yates A, Zerbino D, Zhang Y, Aken B, Choudhary JS, Gerstein M, Guigó R, Hubbard TJP, Kellis M, Paten B, Reymond A, Tress ML, Flicek P. GENCODE reference annotation for the human and mouse genomes. Nucleic Acids Res. 2019 Jan 8;47(D1):D766-D773. PubMed PMID: 30357393 [Article]
+
+1. Forsthuber A, Lipp K, Andersen L, Ebersberger S, Graña-Castro O, Ellmeier W, Petzelbauer P, Lichtenberger BM, Loewe R. CXCL5 as regulator of neutrophil function in cutaneous melanoma. J Invest Dermatol.. 2019 Jan;139(1):186-194. PubMed PMID: 30009831 . [Article]

--- a/content/en/publications/2020.md
+++ b/content/en/publications/2020.md
@@ -1,0 +1,46 @@
+---
+title: '2020'
+date: 2021-24-01
+menu:
+  footer_secondary:
+---
+
+1. Midkine rewires the melanoma microenvironment toward a tolerogenic and immune-resistant state. Cerezo-Wallis D, Contreras-Alcalde M, Troulé K, Catena X, Mucientes Cynthia, G. Calvo T, Cañón E, Tejedo, C, Pennacchi C. P, Hogan S, Kölblinger P, Tejero H, Chen X.A, Ibarz N, Graña-Castro O, Martinez L, Muñoz J, Ortiz-Romero P, Rodriguez-Peralto JL, Gómez-López G, Al-Shahrour F, Rabadán R, Levesque MP, Olmeda D, S.Soengas M. Nat Med. 2020. Oct. 19. doi: 10.1038/s41591-020-1073-3. [Article]
+
+1. An analysis of tissue-specific alternative splicing at the protein level. Rodriguez JM, Pozo F, Di Domenico T, Vazquez J, Tress L.M. PLoS Comput. Biol. 2020 Oct 5. Online ahead of print. doi: 10.1371/journal.pcbi.1008287. [Article]
+
+1. Global hyperactivation of enhancers stabilizes human and mouse naive pluripotency through inhibition of CDK8/19 Mediator kinases. Lynch J C, Bernard R, Martínez-Val A, Shahbazi N. M, Nóbrega-Pereira S, Calvo I, Blanco-Aparicio C, Tarantino C, Garreta E, Richart-Ginés L, Alcazar N, Graña-Castro O, Gómez-López G, Aksoy I, Muñoz-Martín M, Martínez S, Martínez S, Ortega S, Prieto S, Simboeck E, Camasses A, Attolini Stephan-Otto C, Fernandez F.A, Sierra I.M, Fraga F.M, Pastor J, Fisher D, Montserrat N, Savatier P, Muñoz J, Zernicka-Goetz M, Serrano M. Nat Cell Biol. 2020 Sep 28. Online ahead of print. doi: 10.1038/s41556-020-0573-1. PMID: 32989249 [Article]
+
+1. MicroRNA expression profiles in molecular subtypes of clear-cell renal cell carcinoma are associated with clinical outcome and repression of specific mRNA targets. Verbiest A, Van Hoef V, Rodriguez-Antona C, García-Donas J, Graña-Castro O, Albersen M, Baldewijns M, Laenen A, Roussel E, Schöffski P, Wozniak A, Caruso S, Couchy G, Zucman-Rossi J, Beuselinck B. PLoS One. 2020 Sep 11;15(9):e0238809. doi: 10.1371/journal.pone.0238809. PMID: 32915890 [Article]
+
+1. Tumor regression and resistance mechanisms upon CDK4 and RAF1 inactivation in KRAS/P53 mutant lung adenocarcinomas. Esteban-Burgos L, Wang H, Nieto P, Zheng J, Blanco-Aparicio C, Varela C, Gómez-López G, Fernández-García F, Sanclemente M, Guerra C, Drosten M, Galán J, Caleiras E, Martínez-Torrecuadrada J, Fajas L, Peng S-B, Santamaría D, Musteanu M, Barbacid M. PNAS. 2020 Sept. 10. Online ahead of print. doi: 10.1073/pnas.2002520117. PMID: 32913049 [Article]
+    
+1. DREIMT: a drug repositioning database and prioritization tool for immunomodulation. Troulé K, López-Fernández H, García-Martín S, Reboiro-Jato M, Carretero-Puche C, Martorell-Marugán J, Martín-Serrano G, Carmona-Sáez P, González-Peña D, Al-Shahrour F, Gómez-López G. Bioinformatics. 2020 Aug. 20. Online ahead of print. doi: 10.1093/bioinformatics/btaa727. PMID: 32818254 [Article]
+
+1. TGF-β induced IGFBP-3 is a key paracrine factor from activated pericytes that promotes colorectal cancer cell migration and invasion. Navarro R, Tapia-Galiseo A, Martín-García L, Tarín C, Corbacho C, Gómez-López G, Sánchez-Tirado E, Campuzano S, González-Cortés A, Yáñez-Sedeño P, Compte M, Álvarez-Vallina L, Sanz L. Mol Oncol. 2020 Aug 7. Online ahead of print. doi: 10.1002/1878-0261.12779. PMID: 32767843 [Article]
+
+1. A user guide for the online exploration and visualization of PCAWG data. Goldman M.J, Zhan J, A.Fonseca N, Cortés-Ciriano I, Xiang Q,  Craft B, Piñeiro-Yáñez E, D. O’Connor B, Bazant W, Barrera E, Muñoz-Pomer A, Petryszak R, Fülgrabe A, Al-Shahrour F, Keays M, Haussler D, N.Weinstein J, Huber W, Valencia A, J. Park P, Papatheodorou I,  Zhu J, Ferretti V, Vazquez M. Nat. Comm. 2020 Jul 7; 11, 3400. doi: 10.1038/s41467-020-16785-6. PMID: 32636365 [Article]
+
+1. Transient exposure to miR-203 enhances the differentiation capacity of established  pluripotent stem cells. Salazar-Roa M, Trakala M, Álvarez-Fernandez M, Valdés-Mora F, Zhong C, Muñoz J, Yu Y, J Peters T, Graña-Castro O, Serrano R, Zapatero-Solana E,  Abad M, Bueno M.J, Gómez de Cedrón M, Fernández-Piqueras J, Serrano M, Blasco M.A, Wang D-Z, J Clark S, Izpisua-Belmonte JC, Ortega S, Malumbres M. Embo J. 2020 Jul 2; Online ahead of print. doi: 10.15252/embj.2019104324. PMID: 32614092 [Article]
+
+1. The GATA3 X308_Splice breast cancer mutation is a hormone context-dependent oncogenic driver. Hruschka N, Kalisz M, Subijana M, Graña-Castro O, Del Cano-Ochoa F, Paré Brunet L, Chernukhin I, Sagrera A, De Reynies A, Kloesch B, Chin S-F, Burgués O, Andreu D, Bermejo B, Cejalvo JM, Sutton J, Caldas C, Ramón-Maiques S, S Carroll J, Prat A, X Real F, Martinelli P. Oncogene. 2020 Jun 25; Online ahead of print. doi: 10.1038/s41388-020-1376-3. PMID: 32587399 [Article]
+
+1. Interpreting molecular similarity between patients as a determinant of disease comorbidity relationships. Sánchez-Valle J, Tejero H, Fernández JM, Juan D, Urda-García B, Capella-Gutiérrez S, Al-Shahrour F, Tabarés-Seisdedos R, Baudot A, Pancaldi V, Valencia A. Nat Commun. 2020 Jun 5;11(1):2854. doi: 10.1038/s41467-020-16540-x. PMID: 32504002 [Article]
+
+1. Discovery of new targets to control metastasis in pancreatic cancer by single cell transcriptomics analysis of circulating tumor cells. Dimitrov-Markov S, Perales-Patón J, Bockorny B, Dopazo A, Muñoz M, Baños N, Bonilla V, Menendez C, Duran Y, Huang L, Perea S, Muthuswamy SK, Al-Shahrour F, Lopez-Casas PP, Hidalgo M. Mol Cancer Ther. 2020 Jun 4:molcanther.1166.2020. doi: 10.1158/1535-7163.MCT-19-1166. Online ahead of print. PMID: 32499301 [Article]
+
+1. Autocrine CCL5 effect mediates trastuzumab resistance by ERK pathway activation in HER2-positive breast cancer. Zazo S, González-Alonso P, Martin-Aparicio E, Chamizo C, Luque M, Sanz-Alvarez M, Mínguez P, Gómez-López G, Cristobal I, Caramés C, García-Foncillas J, Eroles P, Lluch A, Arpí O, Rovira A, Albanell J, Madoz-Gúrpide J, Rojo F. Mol Cancer Ther. 2020 May 13. pii: molcanther.1172.2019. PubMed PMID:32404410 [Article]
+
+1. How can bioinformatics contribute to the routine application of personalized precision medicine? Carretero-Puche, C, García-Martín S, García-Carbonero R, Gómez-López G, Al-Shahrour, F.  Expert Rev. Precis. Med.  2020 May 7. doi:10.1080/23808993.2020.1758062. [Article]
+
+1. Metatax: Metataxonomics with a Compi-Based Pipeline for Precision Medicine. Osvaldo Graña-Castro, Hugo López-Fernández, Alba Nogueira-Rodríguez, Florentino Fdez-Riverola, Fátima Al-Shahrour, Daniel Glez-Peña. Interdiscip Sci Comput Life Sci. 2020 Apr 30; doi:10.1007/s12539-020-00368-6. PubMed PMID: 32350726 [Article]
+
+1. The Hippo Pathway Transducers YAP1/TEAD Induce Acquired Resistance to Trastuzumab in HER2-Positive Breast Cancer. González-Alonso P, Zazo S, Martín-Aparicio E, Luque M, Chamizo C, Sanz-Álvarez M, Minguez P, Gómez-López G, Cristóbal I, Caramés C, García-Foncillas J, Eroles P, Lluch A, Arpí O, Rovira A, Albanell J, Piersma SR, Jimenez CR, Madoz-Gúrpide J, Rojo F. Cancers. 2020, 12(5), 1108. PubMed PMID: 32365528 [Article]
+
+1. CDK4/6 Inhibitors Impair Recovery from Cytotoxic Chemotherapy in Pancreatic Adenocarcinoma. Salvador-Barbero, B., Álvarez-Fernández, M., Zapatero-Solana, E., El Bakkali, A., Menéndez, M. del C., López-Casas, P.P., Di Domenico, T., Xie, T., VanArsdale, T., Shields, D.J., Hidalgom M, Malumbres, M. Cancer Cell. 2020 Feb. doi: 10.1016/j.ccell.2020.01.007. PMID: 32109375 [Article]
+
+1. The mTOR Pathway Is Necessary for Survival of Mice With Short Telomeres. Iole Ferrara-Romeo, Paula Martinez, Sarita Saraswati, Kurt Whittemore, Osvaldo Graña-Castro, Lydia Thelma Poluha, Rosa Serrano, Elena Hernandez-Encinas, Carmen Blanco-Aparicio, Juana Maria Flores, Maria A Blasco. Nature Communications. 2020 Mar 3; 11 (1), 1168. doi: 10.1038/s41467-020-14962-1. PubMed PMID: 32127537 [Article]
+
+1. Pan-cancer analysis of whole genomes. The ICGC/TCGA Pan-Cancer Analysis of Whole Genomes Consortium Nature. 2020; 578, 82–93. doi: 10.1038/s41586-020-1969-6. PubMed PMID: 32025007 [Article]
+
+1. Few SINEs of Life: Alu Elements Have Little Evidence For Biological Relevance Despite Elevated Translation. Martinez-Gomez L, Abascal F, Jungreis I, Pozo F, Kellis M, Mudge JM, Tress ML. NAR Genom Bioinform. 2020 Mar;2(1):lqz023. PubMed PMID: 31886458 [Article]

--- a/content/en/publications/2021.md
+++ b/content/en/publications/2021.md
@@ -5,4 +5,48 @@ menu:
   footer_secondary:
 ---
 
-# BAIT GUY
+
+1. Beyondcell: targeting cancer therapeutic heterogeneity in single-cell RNA-seq data. Fustero-Torre C, Jiménez-Santos MJ, García-Martín S, Carretero-Puche C, García-Jimeno L, Ivanchuk V, Di Domenico T, Gómez-López G, Al-Shahrour F. Genome Med. 2021 Dec 16;13(1):187. doi: 10.1186/s13073-021-01001-x. PMID: 34911571; [Article]
+
+1. Melanoma-derived small extracellular vesicles induce lymphangiogenesis and metastasis through an NGFR-dependent mechanism. García-Silva, S., Benito-Martín, A., Graña-Castro O., Nogués, L. et al. Nat Cancer (2021) Nov 25. doi: 10.1038/s43018-021-00272-y [Article]
+
+1. bollito: a flexible pipeline for comprehensive single-cell RNA-seq analyses. García-Jimeno L, Fustero-Torre C, Jiménez-Santos MJ, Gómez-López G, Di Domenico T, Al-Shahrour F. Bioinformatics. 2021 Nov 12:btab758. doi: 10.1093/bioinformatics/btab758. Epub ahead of print. PMID: 34788788; [Article]
+
+1. APPRIS: selecting functionally important isoforms. Rodriguez JM, Pozo F, Cerdán-Vélez D, Di Domenico T, Vázquez J, Tress ML. Nucleic Acids Res. 2021 Nov 10:gkab1058. doi: 10.1093/nar/gkab1058. Online ahead of print. PMID: 34755885; [Article]
+
+1. IL-1 Mediates Microbiome-Induced Inflamm-Ageing of Hematopoietic Stem Cells in Mice. Kovtonyuk LV, Caiado F, Garcia-Martin S, Manz EM, Helbling PM, Takizawa H, Boettcher S, Al-Shahrour F, Nombela-Arrieta C, Slack E, Manz MG. Blood. 2021 Sep 15:blood.2021011570. doi: 10.1182/blood.2021011570. Epub ahead of print. PMID: 34525198; [Article]
+
+1. Deficient adaptation to centrosome duplication defects in neural progenitors causes microcephaly and subcortical heterotopias. González-Martínez J, Cwetsch AW, Martínez-Alonso D, López-Sainz LR, Almagro J, Melati A, Gómez J, Pérez-Martínez M, Megías D, Boskovic J, Gilabert-Juan J, Graña-Castro O, Pierani A, Behrens A, Ortega S, Malumbres M. JCI Insight. 2021 Aug 23;6(16):146364. doi: 10.1172/jci.insight.146364. PMID: 34237032; [Article]
+
+1. The clinical importance of tandem exon duplication-derived substitutions. Martinez-Gomez L, Pozo F, Walsh T.A, Abascal F, Tress L. M. Nucleic Acids Research, 2021;, gkab623. doi: 10.1093/nar/gkab623 PMID: 34302486; [Article]
+
+1. Inhibition of Rag GTPase signaling in mice suppresses B cell responses and lymphomagenesis with minimal detrimental trade-offs. Ortega-Molina A, Lebrero-Fernández C, Sanz A, Deleyto-Seldas N, Plata-Gómez A.B, Menéndez C, Graña-Castro O, Caleiras E, Efeyan A. Cell Reports. 2021 Jul 13: 109372. doi: 10.1016/j.celrep.2021.109372. PMID: 34260908; [Article]
+
+1. NKG2D-CAR-transduced natural killer cells efficiently target multiple myeloma. Leivas A, Valeri A, Córdoba L, García-Ortiz A, Ortiz A, Sánchez-Vega L, Graña-Castro O, Fernández L, Carreño-Tarragona G, Pérez M, Megías D, Paciello ML, Sánchez-Pina J, Pérez-Martínez A, Lee DA, Powell DJ Jr, Río P, Martínez-López J. Blood Cancer J. 2021 Aug 14;11(8):146. doi: 10.1038/s41408-021-00537-w. PMID: 34392311; [Article]
+
+1. Inactivation of EMILIN-1 by Proteolysis and Secretion in Small Extracellular Vesicles Favors Melanoma Progression and Metastasis. Amor López A, Mazariegos MS, Capuano A, Ximénez-Embún P, Hergueta-Redondo M, Recio JÁ, Muñoz E, Al-Shahrour F, Muñoz J, Megías D, Doliana R, Spessotto P, Peinado H. Int J Mol Sci. 2021 Jul 9;22(14):7406. doi: 10.3390/ijms22147406. PMID: 34299025; [Article]
+
+1. A comprehensive database for integrated analysis of omics data in autoimmune diseases. Martorell-Marugán J, López-Domínguez R, García-Moreno A, Toro-Domínguez D, Villatoro-García JA, Barturen G, Martín-Gómez A, Troule K, Gómez-López G, Al-Shahrour F, González-Rumayor V, Peña-Chilet M, Dopazo J, Sáez-Rodríguez J, Alarcón-Riquelme ME, Carmona-Sáez P. BMC Bioinformatics. 2021 Jun 24;22(1):343. doi: 10.1186/s12859-021-04268-4. PMID: 34167460; [Article]
+
+1. MicroRNAs Targeting HIF-2α, VEGFR1 and/or VEGFR2 as Potential Predictive Biomarkers for VEGFR Tyrosine Kinase and HIF-2α Inhibitors in Metastatic Clear-Cell Renal Cell Carcinoma. Kinget, L.; Roussel, E.; Verbiest, A.; Albersen, M.; Rodríguez-Antona, C.; Graña-Castro, O.; Inglada-Pérez, L.; Zucman-Rossi, J.; Couchy, G.; Job, S.; de Reyniès, A.; Laenen, A.; Baldewijns, M.; Beuselinck, B. Cancers 2021, 13, 3099. doi: 10.3390/cancers13123099 PMID: 34205829; [Article]
+
+1. Compi: a framework for portable and reproducible pipelines. López-Fernández H, Graña-Castro O, Nogueira-Rodríguez A, Reboiro-Jato M, Glez-Peña D. PeerJ Computer Science. 2021 June 18; doi: 10.7717/peerj-cs.593 PMID: 34239974; [Article]
+
+1. Assessing the functional relevance of splice isoforms. Pozo F, Martinez-Gomez L, Walsh TA, Rodriguez JM, Di Domenico T, Abascal F, Vazquez J, Tress ML.
+    NAR Genom Bioinform. 2021 May 22;3(2):lqab044. doi: 10.1093/nargab/lqab044. PMID: 34046593; [Article]  
+
+1. RANK links senescence to stemness in the mammary epithelia, delaying tumor onset but increasing tumor aggressiveness. Benítez S, Cordero A, Santamaría G.P,  Redondo-Pedraza J, Rocha S.A, Collado-Solé A, Jimenez M, Sanz-Moreno A, Yoldi G, Santos C. J, De Benedictis I, Gómez-Aleza C, Da Silva-Álvarez S, Troulé K, Gómez-López G, Alcazar N, Palmero I, Collado M, Serrano M, Gonzalez-Suarez E. Developmental Cell. 2021 May 17; doi:10.1016/j.devcel.2021.04.022. PMID: 34004159; [Article]
+
+1. Dianhydrogalactitol Overcomes Multiple Temozolomide Resistance Mechanisms in Glioblastoma. Jiménez-Alcázar M, Curiel-García Á, Nogales P, Perales-Patón J, Schuhmacher AJ, Galán-Ganga M, Zhu L, Lowe SW, Al-Shahrour F, Squatrito M. Mol Cancer Ther. 2021 Jun;20(6):1029-1038. doi: 10.1158/1535-7163.MCT-20-0319. Epub 2021 Apr 12. PMID: 33846235; [Article]
+
+1. MicroRNAs Possibly Involved in the Development of Bone Metastasis in Clear-Cell Renal Cell Carcinoma. Kinget L, Roussel E, Lambrechts D, Boeckx B, Vanginderhuysen L, Albersen M, Rodríguez-Antona C, Graña-Castro O, Inglada-Pérez L, Verbiest A, Zucman-Rossi J, Couchy G, Caruso S, Laenen A, Baldewijns M, Beuselinck B. Cancers (Basel). 2021 Mar 28;13(7):1554. doi: 10.3390/cancers13071554. PMID: 33800656; [Article]
+
+1. Short and dysfunctional telomeres sensitize the kidneys to develop fibrosis. Saraswati, S., Martínez, P., Graña-Castro, O. Blasco M.A. Nat Aging 1, 269–283 (2021). doi: 10.1038/s43587-021-00040-8. [Article]
+
+1. Association between BRCA2 alterations and intraductal and cribriform histologies in prostate cancer. Lozano R, Salles D.C, Shahneen S, Aragón M.I, Thorne H, López-Campos F, Rubio-Briones J, Gutierrez-Pecharroman M.A, Maldonado L, Di Domenico T,  Sanz A, Prieto J.D, García I, Pacheco I.M, Garcés T, Llacer C, Romero-Laorden N, Zambrana F, López-Casas P.P, Llorente D, Mateo J, Pritchard C.C, Antonarakis S.E, Olmos D, Lotan L.T, Castro E. Eur. J. Cancer. 2021 Feb 21;147:74-83. doi: 10.1016/j.ejca.2021.01.027. Online ahead of print. PMID: 33626496; [Article]
+
+1. GENCODE 2021. Frankish A, Diekhans M, Jungreis I, Lagarde J, Loveland E.J,Mudge J.M, Sisu C, Wright J.C, Armstrong J, Barnes I, Berry A, Bignell A, Boix C, Carbonell Sala S, Cunningham F, Di Domenico T, Donaldson S, Fiddes I.T, García Girón C, Gonzalez JM, Grego T, Hardy M, Hourlier t, Howe K.L, Hunt T, Izuogu OG, Johnson R, Martin FJ, Martínez L, Mohanan S, Muir P, Navarro C.P.F, Parker A, Pei V, Pozo F, Calvet Riera F, Ruffier M, Schmitt B.M, Stapleton E, Suner M-M, Sycheva I, Uszczynska-Ratajczak B, Wolf M.Y, Xu J, Yang Y.T, Yates A, Zerbino D, Zhang Y, Choudhary JS, Gerstein M, Guigó R, Hubbard J.P. T, Kellis M, Paten B, Tress M.L, Flicek P. Nucleic Acids Res, Volume 49, Issue D1, 8 January 2021, Pages D916–D923, doi: 10.1093/nar/gkaa1087 PMID: 33270111; [Article]
+
+1. CSVS, a crowdsourcing database of the Spanish population genetic variability. Peña-Chilet M, Roldán G, Perez-Florido J, Ortuño FM, Carmona R, Aquino V, Lopez-Lopez D, Loucera C, Fernandez-Rueda JL, Gallego A, García-Garcia F, González-Neira A, Pita G, Núñez-Torres R, Santoyo-López J, Ayuso C, Minguez P, Avila-Fernandez A, Corton M, Moreno-Pelayo MÁ, Morin M, Gallego-Martinez A, Lopez-Escamez JA, Borrego S, Antiñolo G, Amigo J, Salgado-Garrido J, Pasalodos-Sanchez S, Morte B; Spanish Exome Crowdsourcing Consortium, Carracedo Á, Alonso Á, Dopazo J. Nucleic Acids Res. 2021 Jan 8;49(D1):D1130-D1137. doi: 10.1093/nar/gkaa794. PMID: 32990755; [Article]
+
+1. Spleen plays a major role in DLL4-driven acute T-cell lymphoblastic leukemia. Xiong H, Mancini M, Gobert M, Shen S, Furtado GC, Lira SA, Parkhurst CN, Garambois V, Brengues M, Tadokoro CE, Trimarchi T, Gómez-López G, Singh A, Khiabanian H, Minuzzo S, Indraccolo S, Lobry C, Aifantis I, Herranz D, Lafaille JJ, Maraver A. Theranostics. 2021 Jan 1;11(4):1594-1608. doi: 10.7150/thno.48067. eCollection 2021. PMID: 33408769; [Article]

--- a/content/en/publications/2021.md
+++ b/content/en/publications/2021.md
@@ -1,0 +1,8 @@
+---
+title: '2021'
+date: 2021-24-01
+menu:
+  footer_secondary:
+---
+
+# BAIT GUY

--- a/content/en/publications/2022.md
+++ b/content/en/publications/2022.md
@@ -1,0 +1,16 @@
+---
+title: "2022"
+date: 2018-11-28T15:15:34+10:00
+url: "2022"
+menu:
+  main:
+    weight: 5
+    name: "Publications"
+  footer_secondary:
+    name: "Publications"
+    weight: 5
+description: "Business plan hackathon handshake responsive web design."
+image: "images/gen/content/content-6-thumbnail.webp"
+---
+
+# 2022


### PR DESCRIPTION
The aim of this PR is to migrate our previous publication record ([here](https://bioinformatics.cnio.es/publications/)) to the new website. To do so I've generated a single .md document for each year record. At this moment, It it just that: a markdown numbered list. In the future, I'd be awesome to implement the suggestions made in #2 

At this moment I'm dealing with:

* [] The sidebar menu is limited to 5 elements from oldest to newest. I'd like to change it so that It shows the latest 5 years, at the very least.
* [] Remove each year entry from the footer. Just "publications" should suffice.
* [] A way ¿button? ¿drop down? to show the full record instead of the latest 5.

Marking this as draft for now. Ideas/inputs/suggestions welcome. 