### PR TITLE
Update publications page

### DIFF
--- a/content/en/publications/2021.md
+++ b/content/en/publications/2021.md
@@ -18,11 +18,6 @@ García-Silva, S., Benito-Martín, A., **Graña-Castro O.**, Nogués, L. et al.
 ***Nat Cancer***. 2021 Nov 25. doi: 10.1038/s43018-021-00272-y  
 PMID: [34957415](https://pubmed.ncbi.nlm.nih.gov/34957415/)
 
-#### bollito: a flexible pipeline for comprehensive single-cell RNA-seq analyses.
-**García-Jimeno L**, **Fustero-Torre C**, **Jiménez-Santos MJ**, **Gómez-López G**, **Di Domenico T**, **Al-Shahrour F**.  
-***Bioinformatics***. 2021 Nov 12. doi: 10.1093/bioinformatics/btab758. Epub ahead of print.  
-PMID: [34788788](https://pubmed.ncbi.nlm.nih.gov/34788788/)
-
 #### APPRIS: selecting functionally important isoforms.
 Rodriguez JM, **Pozo F**, **Cerdán-Vélez D**, **Di Domenico T**, Vázquez J, **Tress ML**.  
 ***Nucleic Acids Res***. 2021 Nov 10. doi: 10.1093/nar/gkab1058. Online ahead of print.  

--- a/content/en/publications/2022.md
+++ b/content/en/publications/2022.md
@@ -98,9 +98,9 @@ Sanchez-Burgos L, **Gómez-López G**, **Al-Shahrour F**, Fernandez-Capetillo O.
 ***Sci Rep***. 2022 Jan 31;12(1):1626. doi: 10.1038/s41598-022-05597-x.  
 PMID: [35102208](https://pubmed.ncbi.nlm.nih.gov/35102208/)
 
-#### bollito: a flexible pipeline for comprehensive single-cell RNA-seq analyses.
+#### bollito: a flexible pipeline for comprehensive single-cell RNA-seq analyses.  
 **García-Jimeno L**, **Fustero-Torre C**, **Jiménez-Santos MJ**, **Gómez-López G**, **Di Domenico T**, **Al-Shahrour F**.  
-***Bioinformatics***. 2022 Jan 27;38(4):1155-1156. doi: 10.1093/bioinformatics/btab758.
+***Bioinformatics***. 2022 Jan 27;38(4):1155-1156. doi: 10.1093/bioinformatics/btab758.  
 PMID: [34788788](https://pubmed.ncbi.nlm.nih.gov/34788788/)
 
 #### IL-1 mediates microbiome-induced inflammaging of hematopoietic stem cells in mice

--- a/content/en/publications/2022.md
+++ b/content/en/publications/2022.md
@@ -13,11 +13,6 @@ Ruiz-López E, Jovčevska I, González-Gómez R, **Tejero H**, **Al-Shahrour F**
 ***Sci Rep***. 2022 Dec 30;12(1):2258 doi: 10.1038/s41598-022-27161-3.  
 PMID: [36585418](https://pubmed.ncbi.nlm.nih.gov/36585418/)
 
-#### CALR-mutated cells are vulnerable to combined inhibition of the proteasome and the endoplasmic reticulum stress response.
-Jutzi JS, Marneth AE, **Jiménez-Santos MJ**, Hem J, Guerra-Moreno A, Rolles B, Bhatt S, Myers SA, Carr SA, Hong Y, Pozdnyakova O, van Galen P, **Al-Shahrour F**, Nam AS, Mullally A.  
-***Leukemia***. 2022 Dec 6. doi: 10.1038/s41375-022-01781-0. Epub ahead of print.  
-PMID: [36473980](https://pubmed.ncbi.nlm.nih.gov/36473980/)
-
 #### Phosphoproteomic analysis of neoadjuvant breast cancer suggests that increased sensitivity to paclitaxel is driven by CDK4 and filamin A.
 Mouron S, Bueno MJ, Lluch A, Manso L, Calvo I, Cortes J, Garcia-Saenz JA, Gil-Gil M, Martinez-Janez N, Apala JV, Caleiras E, Ximénez-Embún P, Muñoz J, Gonzalez-Cortijo L, Murillo R, Sánchez-Bayona R, Cejalvo JM, **Gómez-López G**, **Fustero-Torre C**, Sabroso-Lasa S, Malats N, Martinez M, Moreno A, Megias D, Malumbres M, Colomer R, Quintela-Fandino M.  
 ***Nat Commun***. 2022 Dec 7;13(1):7529. doi: 10.1038/s41467-022-35065-z.  
@@ -102,6 +97,11 @@ PMID: [35174975](https://pubmed.ncbi.nlm.nih.gov/35174975/)
 Sanchez-Burgos L, **Gómez-López G**, **Al-Shahrour F**, Fernandez-Capetillo O.  
 ***Sci Rep***. 2022 Jan 31;12(1):1626. doi: 10.1038/s41598-022-05597-x.  
 PMID: [35102208](https://pubmed.ncbi.nlm.nih.gov/35102208/)
+
+#### bollito: a flexible pipeline for comprehensive single-cell RNA-seq analyses.
+**García-Jimeno L**, **Fustero-Torre C**, **Jiménez-Santos MJ**, **Gómez-López G**, **Di Domenico T**, **Al-Shahrour F**.  
+***Bioinformatics***. 2022 Jan 27;38(4):1155-1156. doi: 10.1093/bioinformatics/btab758.
+PMID: [34788788](https://pubmed.ncbi.nlm.nih.gov/34788788/)
 
 #### IL-1 mediates microbiome-induced inflammaging of hematopoietic stem cells in mice
 Kovtonyuk LV, Caiado F, **Garcia-Martin S**, Manz EM, Helbling P, Takizawa H, Boettcher S, **Al-Shahrour F**, Nombela-Arrieta C, Slack E, Manz MG.  

--- a/content/en/publications/2023.md
+++ b/content/en/publications/2023.md
@@ -25,9 +25,9 @@ PMID: [37483622](https://pubmed.ncbi.nlm.nih.gov/37483622/)
 ***Nucleic Acids Res***. 2023 Jul 5;51(W1):W411-W418. doi: 10.1093/nar/gkad412  
 PMID: [37207338](https://pubmed.ncbi.nlm.nih.gov/37207338/)
 
-#### RANK is a poor prognosis marker and a therapeutic target in ER-negative postmenopausal breast cancer
-Ciscar M, Trinidad EM, Perez-Chacon G, Alsaleem M, Jimenez M, **Jimenez-Santos MJ**, Perez-Montoyo H, Sanz-Moreno A, Vethencourt A, Toss M, Petit A, Soler-Monso MT, Lopez V, Gomez-Miragaya J, Gomez-Aleza C, Dobrolecki LE, Lewis MT, Bruna A, Mouron S, Quintela-Fandino M, **Al-Shahrour F**, Martinez-Aranda A, Sierra A, Green AR, Rakha E, Gonzalez-Suarez E.
-***EMBO Mol Med***. 2023 Apr 11;15(4):e16715. doi: 10.15252/emmm.202216715.
+#### RANK is a poor prognosis marker and a therapeutic target in ER-negative postmenopausal breast cancer  
+Ciscar M, Trinidad EM, Perez-Chacon G, Alsaleem M, Jimenez M, **Jimenez-Santos MJ**, Perez-Montoyo H, Sanz-Moreno A, Vethencourt A, Toss M, Petit A, Soler-Monso MT, Lopez V, Gomez-Miragaya J, Gomez-Aleza C, Dobrolecki LE, Lewis MT, Bruna A, Mouron S, Quintela-Fandino M, **Al-Shahrour F**, Martinez-Aranda A, Sierra A, Green AR, Rakha E, Gonzalez-Suarez E.  
+***EMBO Mol Med***. 2023 Apr 11;15(4):e16715. doi: 10.15252/emmm.202216715.  
 PMID: [36880458](https://pubmed.ncbi.nlm.nih.gov/36880458/)
 
 #### PD-L1ATTAC mice reveal the potential of depleting PD-L1 expressing cells in cancer therapy
@@ -45,9 +45,9 @@ Calsina B, **Piñeiro-Yáñez E**, Martínez-Montes ÁM, Caleiras E, Fernández-
 ***Nat Commun***. 2023 Feb 28;14(1):1122. doi: 10.1038/s41467-023-36769-6  
 PMID: [36854674](https://pubmed.ncbi.nlm.nih.gov/36854674/)
 
-#### CALR-mutated cells are vulnerable to combined inhibition of the proteasome and the endoplasmic reticulum stress response
-Jutzi JS, Marneth AE, **Jiménez-Santos MJ**, Hem J, Guerra-Moreno A, Rolles B, Bhatt S, Myers SA, Carr SA, Hong Y, Pozdnyakova O, van Galen P, **Al-Shahrour F**, Nam AS, Mullally A.
-***Leukemia***. 2023 Feb;37(2):359-369. doi: 10.1038/s41375-022-01781-0.
+#### CALR-mutated cells are vulnerable to combined inhibition of the proteasome and the endoplasmic reticulum stress response  
+Jutzi JS, Marneth AE, **Jiménez-Santos MJ**, Hem J, Guerra-Moreno A, Rolles B, Bhatt S, Myers SA, Carr SA, Hong Y, Pozdnyakova O, van Galen P, **Al-Shahrour F**, Nam AS, Mullally A.  
+***Leukemia***. 2023 Feb;37(2):359-369. doi: 10.1038/s41375-022-01781-0.  
 PMID: [36473980](https://pubmed.ncbi.nlm.nih.gov/36473980/)
 
 #### GENCODE: reference annotation for the human and mouse genomes in 2023

--- a/content/en/publications/2023.md
+++ b/content/en/publications/2023.md
@@ -25,6 +25,11 @@ PMID: [37483622](https://pubmed.ncbi.nlm.nih.gov/37483622/)
 ***Nucleic Acids Res***. 2023 Jul 5;51(W1):W411-W418. doi: 10.1093/nar/gkad412  
 PMID: [37207338](https://pubmed.ncbi.nlm.nih.gov/37207338/)
 
+#### RANK is a poor prognosis marker and a therapeutic target in ER-negative postmenopausal breast cancer
+Ciscar M, Trinidad EM, Perez-Chacon G, Alsaleem M, Jimenez M, **Jimenez-Santos MJ**, Perez-Montoyo H, Sanz-Moreno A, Vethencourt A, Toss M, Petit A, Soler-Monso MT, Lopez V, Gomez-Miragaya J, Gomez-Aleza C, Dobrolecki LE, Lewis MT, Bruna A, Mouron S, Quintela-Fandino M, **Al-Shahrour F**, Martinez-Aranda A, Sierra A, Green AR, Rakha E, Gonzalez-Suarez E.
+***EMBO Mol Med***. 2023 Apr 11;15(4):e16715. doi: 10.15252/emmm.202216715.
+PMID: [36880458](https://pubmed.ncbi.nlm.nih.gov/36880458/)
+
 #### PD-L1ATTAC mice reveal the potential of depleting PD-L1 expressing cells in cancer therapy
 Fueyo-Marcos E, Lopez-Pernas G, **Fustero-Torre C**, Antón ME, **Al-Shahrour F**, Fernández-Capetillo O, Murga M.  
 ***Aging (Albany NY)***. 2023 Mar 22;15(6):1791-1807. doi: 10.18632/aging.204598. Epub 2023 Mar 22.  
@@ -40,6 +45,11 @@ Calsina B, **Piñeiro-Yáñez E**, Martínez-Montes ÁM, Caleiras E, Fernández-
 ***Nat Commun***. 2023 Feb 28;14(1):1122. doi: 10.1038/s41467-023-36769-6  
 PMID: [36854674](https://pubmed.ncbi.nlm.nih.gov/36854674/)
 
+#### CALR-mutated cells are vulnerable to combined inhibition of the proteasome and the endoplasmic reticulum stress response
+Jutzi JS, Marneth AE, **Jiménez-Santos MJ**, Hem J, Guerra-Moreno A, Rolles B, Bhatt S, Myers SA, Carr SA, Hong Y, Pozdnyakova O, van Galen P, **Al-Shahrour F**, Nam AS, Mullally A.
+***Leukemia***. 2023 Feb;37(2):359-369. doi: 10.1038/s41375-022-01781-0.
+PMID: [36473980](https://pubmed.ncbi.nlm.nih.gov/36473980/)
+
 #### GENCODE: reference annotation for the human and mouse genomes in 2023
 Frankish A, Carbonell-Sala S, Diekhans M, Jungreis I, Loveland JE, Mudge JM, Sisu C, Wright JC, Arnan C, Barnes I, Banerjee A, Bennett R, Berry A, Bignell A, Boix C, Calvet F, Cerdán-Vélez D, Cunningham F, Davidson C, Donaldson S, Dursun C, Fatima R, Giorgetti S, Giron CG, Gonzalez JM, Hardy M, Harrison PW, Hourlier T, Hollis Z, Hunt T, James B, Jiang Y, Johnson R, Kay M, Lagarde J, Martin FJ, Gómez LM, Nair S, Ni P, **Pozo F**, Ramalingam V, Ruffier M, Schmitt BM, Schreiber JM, Steed E, Suner MM, Sumathipala D, Sycheva I, Uszczynska-Ratajczak B, Wass E, Yang YT, Yates A, Zafrulla Z, Choudhary JS, Gerstein M, Guigo R, Hubbard TJP, Kellis M, Kundaje A, Paten B, **Tress ML**, Flicek P.  
 ***Nucleic Acids Res***. 2023 Jan 6;51(D1):D942-D949. doi: 10.1093/nar/gkac107  
@@ -52,5 +62,5 @@ PMID: [36326833](https://pubmed.ncbi.nlm.nih.gov/36326833/)
 
 #### Pseudoalignment tools as an efficient alternative to detect repeated transposable elements in scRNAseq data
 de Villarreal JM, Kalisz M, **Piedrafita G**, **Graña-Castro O**, Chondronasiou D, Serrano M, Real FX.  
-***Bioinformatics***. 2023 Jan 1;39(1):btac737. doi: 10.1093/bioinformatics/btac737  
+***Bioinformatics***. 2023 Jan 1;39(1):btac737. doi: 10.1093/bioinformatics/btac737
 PMID: [36519825](https://pubmed.ncbi.nlm.nih.gov/36519825/)


### PR DESCRIPTION
- **Added**: RANK pub (2023).
- **Modified**: bollito pub (2021 -> 2022) and CALR-mutated cells pub (2022 ->2023). In order to match printed publication dates.