### PR TITLE
Add file for Bluesky handle verification

### DIFF
--- a/static/.well-known/atproto-did
+++ b/static/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:mkrdjz3skmpevna3oprnarsu


### PR DESCRIPTION
Hey @FranSoriano. I've added this file that's required to authenticate the `bioinformatics.cnio.es` handle in Bluesky. Please check that it's correctly exported to the public part of the site.

I've now added it manually to the server, the important thing would be to check whether it survives an update.